### PR TITLE
use svn url, not trac url

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ cd ./tests
 #you can include wordpress-tests as a git submodule here and Travis CI will init it,
 #if it does not exist, we'll just download it on the fly now
 if [ ! -d "./wordpress-tests" ]; then
-	svn co http://unit-test.svn.wordpress.org/trunk wordpress-tests
+	svn co --ignore-externals http://unit-tests.svn.wordpress.org/trunk/ wordpress-tests
 fi
 
 #grab unittsets-config and move into framework folder

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ cd ./tests
 #you can include wordpress-tests as a git submodule here and Travis CI will init it,
 #if it does not exist, we'll just download it on the fly now
 if [ ! -d "./wordpress-tests" ]; then
-	svn co http://unit-test.trac.wordpress.org/browser/trunk wordpress-tests
+	svn co http://unit-test.svn.wordpress.org/trunk wordpress-tests
 fi
 
 #grab unittsets-config and move into framework folder


### PR DESCRIPTION
When switching to the svn repo, you used the web URL, not the svn URL, which obviously breaks the build.
