### PR TITLE
More flexible setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -11,24 +11,21 @@ export WP_TESTS_DIR=/tmp/wordpress-tests
 # Init database
 mysql -e 'CREATE DATABASE wordpress_test;' -uroot
 
-# Normalize plugin folder name
-plugin_slug=$( echo "${PWD##*/}" | tr -s  '[:upper:]'  '[:lower:]' )
-mkdir ../plugin
-mv * ../plugin
-cd ..
-
 # Grab specified version of WordPress from github
-wget -O wordpress.tar.gz https://github.com/WordPress/WordPress/tarball/$WP_VERSION
+wget -O /tmp/wordpress.tar.gz https://github.com/WordPress/WordPress/tarball/$WP_VERSION
 mkdir -p $WP_CORE_DIR
-tar --strip-components=1 -zxmf wordpress.tar.gz -C $WP_CORE_DIR
+tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
-# Set up testing framework
+# Grab testing framework and config file
 svn co --ignore-externals http://unit-tests.svn.wordpress.org/trunk/ $WP_TESTS_DIR
 
 wget -O $WP_TESTS_DIR/wp-tests-config.php https://raw.github.com/scribu/wordpress-plugin-tests/setup/wp-tests-config.php
 
 # Put various components in proper folders
-mv -f plugin/tests ./tests
-mv -f plugin $WP_CORE_DIR/wp-content/plugins/$plugin_slug
+plugin_slug=$(basename $(pwd))
+plugin_dir=$WP_CORE_DIR/wp-content/plugins/$plugin_slug
 
-cd tests
+cd ..
+mv $plugin_slug $plugin_dir
+
+cd $plugin_dir/tests

--- a/setup.sh
+++ b/setup.sh
@@ -12,14 +12,14 @@ export WP_TESTS_DIR=/tmp/wordpress-tests
 mysql -e 'CREATE DATABASE wordpress_test;' -uroot
 
 # Grab specified version of WordPress from github
-wget -O /tmp/wordpress.tar.gz https://github.com/WordPress/WordPress/tarball/$WP_VERSION
+wget -nv -O /tmp/wordpress.tar.gz https://github.com/WordPress/WordPress/tarball/$WP_VERSION
 mkdir -p $WP_CORE_DIR
 tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
 # Grab testing framework and config file
-svn co --ignore-externals http://unit-tests.svn.wordpress.org/trunk/ $WP_TESTS_DIR
+svn co --quiet --ignore-externals http://unit-tests.svn.wordpress.org/trunk/ $WP_TESTS_DIR
 
-wget -O $WP_TESTS_DIR/wp-tests-config.php https://raw.github.com/scribu/wordpress-plugin-tests/setup/wp-tests-config.php
+wget -nv -O $WP_TESTS_DIR/wp-tests-config.php https://raw.github.com/scribu/wordpress-plugin-tests/setup/wp-tests-config.php
 
 # Put various components in proper folders
 plugin_slug=$(basename $(pwd))

--- a/wp-tests-config.php
+++ b/wp-tests-config.php
@@ -1,7 +1,7 @@
 <?php
 /* Path to the WordPress codebase you'd like to test. Add a backslash in the end. */
 
-define( 'ABSPATH', dirname( dirname( dirname( __FILE__ ) ) ) . '/wp/' );
+define( 'ABSPATH', getenv( 'WP_CORE_DIR' ) . '/' );
 
 define( 'DB_NAME', 'wordpress_test' );
 define( 'DB_USER', 'root' );


### PR DESCRIPTION
By setting up different values for environment variables, we can use the same testing bootstrap for both local testing and travis builds.

Will require some changes to the 'master' branch too.
