### PR TITLE
More flexible setup script (continued)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  
+    - 5.3
+    - 5.4
+
 env:
- - WP_VERSION=master WP_MULTISITE=0
- - WP_VERSION=3.4.1 WP_MULTISITE=0
- - WP_VERSION=3.3.2 WP_MULTISITE=0
- - WP_VERSION=3.2.1 WP_MULTISITE=0 
- - WP_VERSION=master WP_MULTISITE=1
- - WP_VERSION=3.4.1 WP_MULTISITE=1
- - WP_VERSION=3.3.2 WP_MULTISITE=1 
- - WP_VERSION=3.2.1 WP_MULTISITE=1
+    - WP_VERSION=master WP_MULTISITE=0
+    - WP_VERSION=3.4.1 WP_MULTISITE=0
+    - WP_VERSION=3.3.2 WP_MULTISITE=0
+    - WP_VERSION=3.2.1 WP_MULTISITE=0 
+    - WP_VERSION=master WP_MULTISITE=1
+    - WP_VERSION=3.4.1 WP_MULTISITE=1
+    - WP_VERSION=3.3.2 WP_MULTISITE=1 
+    - WP_VERSION=3.2.1 WP_MULTISITE=1
 
 before_script:
-  - wget https://raw.github.com/benbalter/wordpress-plugin-tests/setup/setup.sh
-  - sh setup.sh
-  - cd ../tests
-    
+    - wget https://raw.github.com/benbalter/wordpress-plugin-tests/setup/setup.sh
+    - sh setup.sh
+    - cd ../tests
+
 script: phpunit All

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
     - WP_VERSION=3.2.1 WP_MULTISITE=1
 
 before_script:
-    - wget https://raw.github.com/benbalter/wordpress-plugin-tests/setup/setup.sh
-    - sh setup.sh
-    - cd ../tests
+    - wget https://raw.github.com/scribu/wordpress-plugin-tests/setup/setup.sh
+    - source setup.sh
 
 script: phpunit All

--- a/readme.md
+++ b/readme.md
@@ -20,9 +20,30 @@ How to integrate with your plugin
 1. Place [`.travis.yml`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/.travis.yml) file in plugin root folder (you may want to [customize your build settings](http://about.travis-ci.org/docs/user/build-configuration/) here)
 2. Create a subfolder of your plugin called `tests/` and copy over the [`all.php`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/All.php), [`bootstrap.php`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/bootstrap.php), and [`phpunit.xml`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/phpunit.xml) files from this repo's [`test/`](https://github.com/benbalter/wordpress-plugin-tests/tree/master/tests) folder
 3. Customize the newly coppied [`/tests/bootstrap.php`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/bootstrap.php) with the path to your plugin file 
-4. If you want to be able to test locally, add wordpress-tests as a submodule of the `tests/` folder by running the command `git submodule add https://github.com/nb/wordpress-tests.git tests/wordpress-tests` from your plugin's root directory (*optional*)
-5. [Activate Travis CI](http://travis-ci.org/profile) for your plugin
-6. Add tests to the `tests/` folder following the instructions below
+4. [Activate Travis CI](http://travis-ci.org/profile) for your plugin
+5. Add tests to the `tests/` folder following the instructions below
+
+Running the tests locally
+----------------------------------
+1. Check out a copy of the WP tests framework: 
+
+```bash
+svn co --ignore-externals http://unit-tests.svn.wordpress.org/trunk/ ~/wordpress-tests
+```
+
+2. Add the environment variables to your `.bashrc` profile:
+
+```bash
+export WP_TEST_DIR=~/wordpress-tests
+export WP_CORE_DIR=~/path/to/wordpress-core
+```
+
+3. Run the tests
+
+```bash
+cd /path/to/your-plugin/tests
+phpunit
+```
 
 The Tests
 ---------

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ First, set up the WP testing framework: http://make.wordpress.org/core/handbook/
 Then, add the environment variables to your `.bashrc` file:
 
 ```bash
-export WP_TEST_DIR=~/wordpress-tests
+export WP_TESTS_DIR=~/wordpress-tests
 export WP_CORE_DIR=~/path/to/wordpress-core
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -25,20 +25,16 @@ How to integrate with your plugin
 
 Running the tests locally
 ----------------------------------
-1. Check out a copy of the WP tests framework: 
+First, set up the WP testing framework: http://make.wordpress.org/core/handbook/automated-testing/#installation
 
-```bash
-svn co --ignore-externals http://unit-tests.svn.wordpress.org/trunk/ ~/wordpress-tests
-```
-
-2. Add the environment variables to your `.bashrc` profile:
+Then, add the environment variables to your `.bashrc` file:
 
 ```bash
 export WP_TEST_DIR=~/wordpress-tests
 export WP_CORE_DIR=~/path/to/wordpress-core
 ```
 
-3. Run the tests
+Finally, run the tests:
 
 ```bash
 cd /path/to/your-plugin/tests

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,9 +10,9 @@
  * Note: Do note change the name of this file. PHPUnit will automatically fire this file when run.
  *
  */
- 
+
 $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( 'your-plugin/your-plugin.php' ),
 );
 
-require dirname( __FILE__ ) . '/wordpress-tests/bootstrap.php';
+require getenv( 'WP_TESTS_DIR' ) . '/bootstrap.php';


### PR DESCRIPTION
Changes to complement #12

Example project using this setup successfully: http://travis-ci.org/#!/scribu/wp-posts-to-posts

The main benefit is that, locally, you can have a single check-out of the testing framework stored wherever and use it for multiple projects.
