### PR TITLE
Don't download Core tests

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,9 @@
 #!/bin/sh
 
-# WordPress test setup script for Travis CI 
-#
-# Author: Benjamin J. Balter ( ben@balter.com | ben.balter.com )
-# License: GPL3
-
 export WP_CORE_DIR=/tmp/wordpress
-export WP_TESTS_DIR=/tmp/wordpress-tests
+
+plugin_slug=$(basename $(pwd))
+plugin_dir=$WP_CORE_DIR/wp-content/plugins/$plugin_slug
 
 # Init database
 mysql -e 'CREATE DATABASE wordpress_test;' -uroot
@@ -16,19 +13,12 @@ wget -nv -O /tmp/wordpress.tar.gz https://github.com/WordPress/WordPress/tarball
 mkdir -p $WP_CORE_DIR
 tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
 
-# Grab testing framework
-svn co --quiet --ignore-externals http://unit-tests.svn.wordpress.org/trunk/ $WP_TESTS_DIR
-
-# Grab Travis-CI specific config file
-wget -nv -O $WP_TESTS_DIR/wp-tests-config.php https://raw.github.com/benbalter/wordpress-plugin-tests/setup/wp-tests-config.php
-
-# Put various components in proper folders
-plugin_slug=$(basename $(pwd))
-plugin_dir=$WP_CORE_DIR/wp-content/plugins/$plugin_slug
-
-#move plugin itself into place
+# move plugin into place
 cd ..
 mv $plugin_slug $plugin_dir
 
-#put shell in tests folder
+# Grab Travis-CI specific config file
+wget -nv -O $plugin_dir/tests/wp-tests-config.php https://raw.github.com/benbalter/wordpress-plugin-tests/setup/wp-tests-config.php
+
+# prepare shell for phpunit call
 cd $plugin_dir/tests


### PR DESCRIPTION
Recently, all the test library files have been [moved to a separate directory](http://unit-tests.trac.wordpress.org/ticket/137), so we could download only that dir when testing.

Also, it makes more sense now for plugins to have the test lib as a submodule.
