### PR TITLE
[Documentation] Remove reference to all.php in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ Assumptions
 How to integrate with your plugin
 ----------------------------------
 1. Place [`.travis.yml`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/.travis.yml) file in your plugin's root folder (you may want to [customize your build settings](http://about.travis-ci.org/docs/user/build-configuration/) here)
-2. Create a subfolder of your plugin called `tests/` and copy over the [`all.php`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/All.php), [`bootstrap.php`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/bootstrap.php), and [`phpunit.xml`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/phpunit.xml) files from this repo's [`test/`](https://github.com/benbalter/wordpress-plugin-tests/tree/master/tests) folder
+2. Create a subfolder of your plugin called `tests/` and copy over the [`bootstrap.php`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/bootstrap.php) and [`phpunit.xml`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/phpunit.xml) files from this repo's [`test/`](https://github.com/benbalter/wordpress-plugin-tests/tree/master/tests) folder
 3. Customize the newly coppied [`/tests/bootstrap.php`](https://github.com/benbalter/wordpress-plugin-tests/blob/master/tests/bootstrap.php) with the path to your plugin file 
 4. [Activate Travis CI](http://travis-ci.org/profile) for your plugin
 5. Add tests to the `tests/` folder following the instructions below


### PR DESCRIPTION
The linked to file no longer exists.

Edit: This is a partial dupe of #20.
