### PR TITLE
Remove Movement To tests/ Directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,6 @@ then
 fi
 
 # prepare shell for phpunit call
-cd $plugin_dir/tests
+cd $plugin_dir
 
 set +x


### PR DESCRIPTION
This is the change required in the other branch that corresponds to https://github.com/benbalter/wordpress-plugin-tests/pull/26

Also changes tests to be - not _ and adds in the submodule permanently.
